### PR TITLE
Add a Plugins tab with import and Documents-backed storage

### DIFF
--- a/Sources/BluetoothExplorer/ContentView.swift
+++ b/Sources/BluetoothExplorer/ContentView.swift
@@ -2,7 +2,7 @@ import SwiftUI
 import BluetoothExplorerUI
 
 enum ContentTab: String, Hashable {
-    case welcome, home, settings
+    case welcome, home, plugins, settings
 }
 
 struct ContentView: View {
@@ -17,6 +17,12 @@ struct ContentView: View {
             }
             .tabItem { Label("Welcome", systemImage: "heart.fill") }
             .tag(ContentTab.welcome)
+
+            NavigationStack {
+                PluginsView()
+            }
+            .tabItem { Label("Plugins", systemImage: "puzzlepiece.extension.fill") }
+            .tag(ContentTab.plugins)
 
             NavigationStack {
                 SettingsView(appearance: $appearance, welcomeName: $welcomeName)
@@ -58,9 +64,6 @@ struct SettingsView : View {
                 Text("System").tag("")
                 Text("Light").tag("light")
                 Text("Dark").tag("dark")
-            }
-            NavigationLink("Plugins") {
-                PluginsView()
             }
             if let version = Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String,
                let buildNumber = Bundle.main.infoDictionary?["CFBundleVersion"] as? String {

--- a/Sources/BluetoothExplorerModel/Model/PluginManager.swift
+++ b/Sources/BluetoothExplorerModel/Model/PluginManager.swift
@@ -62,9 +62,59 @@ public final class PluginManager {
 
     // MARK: Loading
 
-    /// Scan the engine bundle's `Plugins/` directory for `*.bleplugin.json` manifests.
-    public func loadBundledPlugins() {
-        loadBundledPlugins(from: PluginEngineResources.bundle)
+    /// Where installed plugins live on disk, once `loadInstalledPlugins()` has run.
+    public private(set) var directory: PluginDirectory?
+
+    /// Install bundled plugins into Documents on first launch, then load everything from there.
+    ///
+    /// This is the normal startup path: bundled and imported plugins end up in the same directory,
+    /// so there is a single load path and the user can see and manage every plugin in one place.
+    public func loadInstalledPlugins() {
+        do {
+            let directory = try PluginDirectory.default()
+            self.directory = directory
+            let freshlyInstalled = Set(try directory.installBundledPlugins(from: PluginEngineResources.bundle))
+            load(from: directory, bundledIdentifiers: freshlyInstalled)
+        } catch {
+            // Falling back to the read-only bundle keeps parsing working even if Documents is
+            // unavailable; the user just cannot manage plugins this session.
+            loadBundledPlugins(from: PluginEngineResources.bundle)
+        }
+    }
+
+    private func load(from directory: PluginDirectory, bundledIdentifiers: Set<String>) {
+        for manifestURL in directory.installedManifestURLs() {
+            do {
+                let loaded = try PluginLoader.load(manifestURL: manifestURL, verifyHash: true)
+                // Anything installed from the app bundle is "bundled", whether it landed this
+                // launch or a previous one; the install record is the source of truth.
+                let source: Source = bundledIdentifiers.contains(loaded.manifest.identifier)
+                    || bundledManifestIdentifiers.contains(loaded.manifest.identifier)
+                    ? .bundled : .imported
+                register(loaded.plugin, manifest: loaded.manifest, source: source)
+            } catch let failure as PluginLoadFailure {
+                recordFailure(failure, source: .imported)
+            } catch {
+                recordFailure(PluginLoadFailure(manifestName: manifestURL.lastPathComponent,
+                                                underlying: nil, message: "\(error)"), source: .imported)
+            }
+        }
+        rebuild()
+    }
+
+    /// Identifiers shipped inside the app bundle, used to label a plugin's origin in the UI.
+    private var bundledManifestIdentifiers: Set<String> {
+        let urls = PluginEngineResources.bundle.urls(
+            forResourcesWithExtension: "json", subdirectory: "Plugins") ?? []
+        var identifiers = Set<String>()
+        for url in urls.map({ $0 as URL })
+        where url.lastPathComponent.hasSuffix(PluginDirectory.manifestSuffix) {
+            guard let data = try? Data(contentsOf: url),
+                  let manifest = try? JSONDecoder().decode(PluginManifest.self, from: data)
+            else { continue }
+            identifiers.insert(manifest.identifier)
+        }
+        return identifiers
     }
 
     /// Scan a bundle's `Plugins/` directory for `*.bleplugin.json` manifests and load each.
@@ -77,6 +127,42 @@ public final class PluginManager {
             recordFailure(failure)
         }
         rebuild()
+    }
+
+    // MARK: Importing
+
+    /// Why an import failed, in a form the UI can show directly.
+    public struct ImportError: Error, Sendable, CustomStringConvertible {
+        public let message: String
+        public var description: String { message }
+    }
+
+    /// Import a plugin the user picked. The manifest and its module are validated, then copied
+    /// into the plugin directory and loaded.
+    @discardableResult
+    public func importPlugin(manifestURL: URL) -> Result<PluginID, ImportError> {
+        guard let directory else {
+            return .failure(ImportError(message: "Plugin storage is unavailable."))
+        }
+        #if canImport(Darwin)
+        // Files handed over by the document picker live outside the sandbox until claimed.
+        let scoped = manifestURL.startAccessingSecurityScopedResource()
+        defer { if scoped { manifestURL.stopAccessingSecurityScopedResource() } }
+        #endif
+        do {
+            let manifest = try directory.importPlugin(manifestURL: manifestURL)
+            let installed = directory.url
+                .appendingPathComponent(PluginDirectory.folderName(for: manifest.identifier), isDirectory: true)
+                .appendingPathComponent(manifestURL.lastPathComponent)
+            let loaded = try PluginLoader.load(manifestURL: installed, verifyHash: true)
+            register(loaded.plugin, manifest: loaded.manifest, source: .imported)
+            rebuild()
+            return .success(loaded.plugin.id)
+        } catch let failure as PluginLoadFailure {
+            return .failure(ImportError(message: failure.message))
+        } catch {
+            return .failure(ImportError(message: "\(error)"))
+        }
     }
 
     /// Load a single plugin from a manifest URL. `verifyHash` enforces the manifest `sha256`.
@@ -112,7 +198,7 @@ public final class PluginManager {
         let id = plugin.id
         wasmPlugins[id] = plugin
         if order.contains(id) == false { order.append(id) }
-        if enabled[id] == nil { enabled[id] = true }
+        if enabled[id] == nil { enabled[id] = Self.storedEnabled(id) }
         sources[id] = source
         displayNames[id] = manifest.name
         versions[id] = manifest.version
@@ -123,18 +209,36 @@ public final class PluginManager {
 
     public func setEnabled(_ isEnabled: Bool, id: PluginID) {
         enabled[id] = isEnabled
+        UserDefaults.standard.set(isEnabled, forKey: Self.enabledKey(id))
         rebuild()
     }
 
+    /// Remove a plugin from the registry and delete it from the plugin directory.
+    ///
+    /// A deleted bundled plugin is not reinstalled on the next launch: the install record still
+    /// lists it, so `installBundledPlugins` considers it already handled.
     public func removePlugin(id: PluginID) {
+        if let directory {
+            try? directory.remove(identifier: id.rawValue)
+        }
         wasmPlugins[id] = nil
         order.removeAll { $0 == id }
         enabled[id] = nil
+        UserDefaults.standard.removeObject(forKey: Self.enabledKey(id))
         sources[id] = nil
         displayNames[id] = nil
         versions[id] = nil
         loadErrors[id] = nil
         rebuild()
+    }
+
+    private static func enabledKey(_ id: PluginID) -> String {
+        "plugin.enabled." + id.rawValue
+    }
+
+    /// Persisted enable state, defaulting to on for a plugin seen for the first time.
+    private static func storedEnabled(_ id: PluginID) -> Bool {
+        UserDefaults.standard.object(forKey: enabledKey(id)) as? Bool ?? true
     }
 
     // MARK: Registry construction

--- a/Sources/BluetoothExplorerModel/Model/Store.swift
+++ b/Sources/BluetoothExplorerModel/Model/Store.swift
@@ -109,7 +109,7 @@ public final class Store {
         self.pluginManager = pluginManager
         setupLog()
         observeValues()
-        pluginManager.loadBundledPlugins()
+        pluginManager.loadInstalledPlugins()
     }
 
     /// The current parser registry snapshot.

--- a/Sources/BluetoothExplorerPluginEngine/PluginDirectory.swift
+++ b/Sources/BluetoothExplorerPluginEngine/PluginDirectory.swift
@@ -1,0 +1,179 @@
+//
+//  PluginDirectory.swift
+//  BluetoothExplorerPluginEngine
+//
+//  On-disk plugin storage under the app's Documents directory.
+//
+//  Every plugin — bundled or user-imported — lives here, so there is one code path for loading and
+//  one place a user can inspect. Bundled plugins are copied in on first launch and refreshed when a
+//  new app build ships a different module; a bundled plugin the user deletes stays deleted, because
+//  the install record remembers that it was already handled once.
+//
+//  Layout:
+//      Documents/Plugins/
+//          <plugin-id>/
+//              <name>.bleplugin.json
+//              <name>.wasm
+//          .installed-bundled.json
+//
+
+import Foundation
+
+public struct PluginDirectory: Sendable {
+
+    /// Root of the plugin store, e.g. `Documents/Plugins`.
+    public let url: URL
+
+    private static let recordName = ".installed-bundled.json"
+
+    public init(url: URL) {
+        self.url = url
+    }
+
+    /// `Documents/Plugins`, created if absent.
+    public static func `default`() throws -> PluginDirectory {
+        let documents = try FileManager.default.url(
+            for: .documentDirectory, in: .userDomainMask, appropriateFor: nil, create: true)
+        let directory = PluginDirectory(url: documents.appendingPathComponent("Plugins", isDirectory: true))
+        try directory.createIfNeeded()
+        return directory
+    }
+
+    public func createIfNeeded() throws {
+        try FileManager.default.createDirectory(at: url, withIntermediateDirectories: true)
+    }
+
+    // MARK: Listing
+
+    /// Manifest URLs for every installed plugin, one per plugin sub-directory.
+    public func installedManifestURLs() -> [URL] {
+        let contents = (try? FileManager.default.contentsOfDirectory(
+            at: url, includingPropertiesForKeys: nil)) ?? []
+        var manifests = [URL]()
+        for entry in contents.map({ $0 as URL }) {
+            // `contentsOfDirectory` on a plain file throws, which is a portable directory test —
+            // `ObjCBool` out-parameters are awkward outside Darwin's Foundation.
+            guard let inner = try? FileManager.default.contentsOfDirectory(
+                at: entry, includingPropertiesForKeys: nil)
+            else { continue }
+            for file in inner.map({ $0 as URL })
+            where file.lastPathComponent.hasSuffix(PluginDirectory.manifestSuffix) {
+                manifests.append(file)
+            }
+        }
+        return manifests.sorted { $0.path < $1.path }
+    }
+
+    public static let manifestSuffix = ".bleplugin.json"
+
+    // MARK: Installing bundled plugins
+
+    /// Copy bundled plugins into the store.
+    ///
+    /// A plugin is installed when it has never been installed before (first launch), or when the
+    /// bundled module's hash differs from the one recorded (a new app build shipped an update).
+    /// Plugins the user deleted are not resurrected.
+    /// - Returns: the identifiers that were installed or refreshed.
+    @discardableResult
+    public func installBundledPlugins(from bundle: Bundle) throws -> [String] {
+        try createIfNeeded()
+        var record = installRecord()
+        var installed = [String]()
+
+        let discovered = bundle.urls(forResourcesWithExtension: "json", subdirectory: "Plugins") ?? []
+        for manifestURL in discovered.map({ $0 as URL })
+        where manifestURL.lastPathComponent.hasSuffix(PluginDirectory.manifestSuffix) {
+            guard let data = try? Data(contentsOf: manifestURL),
+                  let manifest = try? JSONDecoder().decode(PluginManifest.self, from: data)
+            else { continue }
+
+            // The manifest's sha256 identifies this build of the module. Absent one, fall back to
+            // the version string so a plugin without a hash still refreshes across releases.
+            let stamp = manifest.sha256 ?? manifest.version
+            if record[manifest.identifier] == stamp { continue }
+
+            let moduleURL = manifestURL.deletingLastPathComponent()
+                .appendingPathComponent(manifest.module)
+            try install(manifestURL: manifestURL, moduleURL: moduleURL, identifier: manifest.identifier)
+            record[manifest.identifier] = stamp
+            installed.append(manifest.identifier)
+        }
+
+        try write(record: record)
+        return installed
+    }
+
+    /// True when no bundled plugin has ever been installed — i.e. this is a first launch.
+    public var isFirstLaunch: Bool {
+        FileManager.default.fileExists(atPath: recordURL.path) == false
+    }
+
+    // MARK: Importing
+
+    /// Import a plugin the user picked, copying its manifest and module into the store.
+    ///
+    /// `manifestURL` must be a `*.bleplugin.json`; the module named by the manifest is resolved
+    /// alongside it. The plugin is validated before anything is written, so a bad import cannot
+    /// leave a broken plugin on disk.
+    @discardableResult
+    public func importPlugin(manifestURL: URL) throws -> PluginManifest {
+        try createIfNeeded()
+        // Validate first: this parses the module, checks the ABI marker, capability exports and,
+        // when the manifest carries a hash, verifies it.
+        let loaded = try PluginLoader.load(manifestURL: manifestURL, verifyHash: true)
+        let moduleURL = manifestURL.deletingLastPathComponent()
+            .appendingPathComponent(loaded.manifest.module)
+        try install(manifestURL: manifestURL, moduleURL: moduleURL,
+                    identifier: loaded.manifest.identifier)
+        return loaded.manifest
+    }
+
+    /// Delete an installed plugin's directory.
+    public func remove(identifier: String) throws {
+        let directory = url.appendingPathComponent(Self.folderName(for: identifier), isDirectory: true)
+        guard FileManager.default.fileExists(atPath: directory.path) else { return }
+        try FileManager.default.removeItem(at: directory)
+    }
+
+    // MARK: Internals
+
+    private func install(manifestURL: URL, moduleURL: URL, identifier: String) throws {
+        let destination = url.appendingPathComponent(Self.folderName(for: identifier), isDirectory: true)
+        if FileManager.default.fileExists(atPath: destination.path) {
+            try FileManager.default.removeItem(at: destination)
+        }
+        try FileManager.default.createDirectory(at: destination, withIntermediateDirectories: true)
+
+        let moduleData = try Data(contentsOf: moduleURL)
+        let manifestData = try Data(contentsOf: manifestURL)
+        try moduleData.write(to: destination.appendingPathComponent(moduleURL.lastPathComponent))
+        try manifestData.write(to: destination.appendingPathComponent(manifestURL.lastPathComponent))
+    }
+
+    /// A filesystem-safe directory name for a reverse-DNS plugin identifier.
+    public static func folderName(for identifier: String) -> String {
+        var name = ""
+        for character in identifier {
+            if character.isLetter || character.isNumber || character == "." || character == "-" {
+                name.append(character)
+            } else {
+                name.append("_")
+            }
+        }
+        return name.isEmpty ? "plugin" : name
+    }
+
+    private var recordURL: URL { url.appendingPathComponent(PluginDirectory.recordName) }
+
+    private func installRecord() -> [String: String] {
+        guard let data = try? Data(contentsOf: recordURL),
+              let record = try? JSONDecoder().decode([String: String].self, from: data)
+        else { return [:] }
+        return record
+    }
+
+    private func write(record: [String: String]) throws {
+        let data = try JSONEncoder().encode(record)
+        try data.write(to: recordURL)
+    }
+}

--- a/Sources/BluetoothExplorerUI/PluginsView.swift
+++ b/Sources/BluetoothExplorerUI/PluginsView.swift
@@ -2,16 +2,25 @@
 //  PluginsView.swift
 //  BluetoothExplorerUI
 //
-//  Lists loaded parser plugins with enable/disable toggles and load-error surfacing.
+//  Manages parser plugins: enable/disable, import from a file, delete, and surface load errors.
+//  Bundled plugins are copied into the app's Documents directory on first launch, so everything
+//  listed here lives in one place the user can inspect.
 //
 
 import SwiftUI
+#if canImport(UniformTypeIdentifiers)
+import UniformTypeIdentifiers
+#endif
 import BluetoothExplorerModel
 
 public struct PluginsView: View {
 
     @Environment(Store.self)
     var store: Store
+
+    // Not `private`: Skip's bridging requires @State properties to be at least internal.
+    @State var isImporting = false
+    @State var importError: String?
 
     public init() {}
 
@@ -21,14 +30,73 @@ public struct PluginsView: View {
                 ForEach(store.pluginManager.plugins) { state in
                     row(for: state)
                 }
+                .onDelete { offsets in
+                    delete(at: offsets)
+                }
             } header: {
                 Text("Parsers")
             } footer: {
-                Text("Plugins decode advertisement and characteristic values. Built-in parsers are native; others are WebAssembly modules.")
+                Text("Plugins decode advertisement and characteristic values. Built-in parsers are native; others are WebAssembly modules stored in the app's Documents folder.")
+            }
+
+            if let error = importError {
+                Section {
+                    Text(verbatim: error)
+                        .font(.caption)
+                        .foregroundColor(.red)
+                } header: {
+                    Text("Import Failed")
+                }
             }
         }
         .navigationTitle("Plugins")
+        #if !os(Android)
+        .toolbar {
+            Button {
+                importError = nil
+                isImporting = true
+            } label: {
+                Label("Import", systemImage: "square.and.arrow.down")
+            }
+        }
+        .fileImporter(
+            isPresented: $isImporting,
+            allowedContentTypes: [.json],
+            allowsMultipleSelection: false
+        ) { result in
+            handleImport(result)
+        }
+        #endif
     }
+
+    // MARK: Actions
+
+    private func handleImport(_ result: Result<[URL], Error>) {
+        switch result {
+        case let .success(urls):
+            guard let url = urls.first else { return }
+            switch store.pluginManager.importPlugin(manifestURL: url) {
+            case .success:
+                importError = nil
+            case let .failure(error):
+                importError = error.message
+            }
+        case let .failure(error):
+            importError = "\(error)"
+        }
+    }
+
+    private func delete(at offsets: IndexSet) {
+        let plugins = store.pluginManager.plugins
+        for index in offsets where index < plugins.count {
+            let state = plugins[index]
+            // Native parsers are compiled in; there is nothing on disk to remove.
+            guard state.source != .native else { continue }
+            store.pluginManager.removePlugin(id: state.id)
+        }
+    }
+
+    // MARK: Rows
 
     @ViewBuilder
     private func row(for state: PluginManager.PluginState) -> some View {

--- a/Tests/BluetoothExplorerPluginEngineTests/PluginDirectoryTests.swift
+++ b/Tests/BluetoothExplorerPluginEngineTests/PluginDirectoryTests.swift
@@ -1,0 +1,135 @@
+//
+//  PluginDirectoryTests.swift
+//  BluetoothExplorerPluginEngineTests
+//
+//  Covers the Documents-backed plugin store: first-launch install of the bundled plugins,
+//  idempotence across launches, that a deleted bundled plugin stays deleted, and import validation.
+//
+//  Every test runs against a temporary directory — never the real Documents folder.
+//
+
+import Foundation
+import Testing
+@testable import BluetoothExplorerPluginEngine
+
+@Suite("Plugin directory")
+struct PluginDirectoryTests {
+
+    private func makeTemporaryDirectory() throws -> PluginDirectory {
+        let url = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent("bleplug-store-\(UUID().uuidString)", isDirectory: true)
+        let directory = PluginDirectory(url: url)
+        try directory.createIfNeeded()
+        return directory
+    }
+
+    private func bundledManifestCount() -> Int {
+        let urls = PluginEngineResources.bundle.urls(
+            forResourcesWithExtension: "json", subdirectory: "Plugins") ?? []
+        return urls.map { $0 as URL }
+            .filter { $0.lastPathComponent.hasSuffix(PluginDirectory.manifestSuffix) }
+            .count
+    }
+
+    @Test("First launch installs every bundled plugin")
+    func firstLaunchInstalls() throws {
+        let directory = try makeTemporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: directory.url) }
+
+        #expect(directory.isFirstLaunch)
+        let installed = try directory.installBundledPlugins(from: PluginEngineResources.bundle)
+        #expect(installed.count == bundledManifestCount())
+        #expect(installed.isEmpty == false)
+        #expect(directory.isFirstLaunch == false)
+        #expect(directory.installedManifestURLs().count == installed.count)
+    }
+
+    @Test("Installed plugins load from the directory")
+    func installedPluginsLoad() throws {
+        let directory = try makeTemporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: directory.url) }
+        try directory.installBundledPlugins(from: PluginEngineResources.bundle)
+
+        for manifestURL in directory.installedManifestURLs() {
+            // Hash verification is on: a copy that lost bytes would fail here.
+            _ = try PluginLoader.load(manifestURL: manifestURL, verifyHash: true)
+        }
+    }
+
+    @Test("A second launch installs nothing new")
+    func secondLaunchIsIdempotent() throws {
+        let directory = try makeTemporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: directory.url) }
+
+        let first = try directory.installBundledPlugins(from: PluginEngineResources.bundle)
+        let second = try directory.installBundledPlugins(from: PluginEngineResources.bundle)
+        #expect(second.isEmpty, "reinstalled on second launch: \(second)")
+        #expect(directory.installedManifestURLs().count == first.count)
+    }
+
+    @Test("A deleted bundled plugin is not resurrected on the next launch")
+    func deletedPluginStaysDeleted() throws {
+        let directory = try makeTemporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: directory.url) }
+
+        let installed = try directory.installBundledPlugins(from: PluginEngineResources.bundle)
+        let victim = try #require(installed.first)
+        try directory.remove(identifier: victim)
+        #expect(directory.installedManifestURLs().count == installed.count - 1)
+
+        let afterRelaunch = try directory.installBundledPlugins(from: PluginEngineResources.bundle)
+        #expect(afterRelaunch.isEmpty, "deleted plugin came back: \(afterRelaunch)")
+        #expect(directory.installedManifestURLs().count == installed.count - 1)
+    }
+
+    @Test("Importing a valid plugin copies it into the store")
+    func importValidPlugin() throws {
+        let source = try makeTemporaryDirectory()
+        let destination = try makeTemporaryDirectory()
+        defer {
+            try? FileManager.default.removeItem(at: source.url)
+            try? FileManager.default.removeItem(at: destination.url)
+        }
+        // Stage a plugin outside the store, the way a user's file would arrive.
+        try source.installBundledPlugins(from: PluginEngineResources.bundle)
+        let staged = try #require(source.installedManifestURLs().first)
+
+        let manifest = try destination.importPlugin(manifestURL: staged)
+        #expect(destination.installedManifestURLs().count == 1)
+        // The imported copy must load and verify against its own hash.
+        let installed = try #require(destination.installedManifestURLs().first)
+        let loaded = try PluginLoader.load(manifestURL: installed, verifyHash: true)
+        #expect(loaded.manifest.identifier == manifest.identifier)
+    }
+
+    @Test("Importing a plugin with a wrong hash fails and writes nothing")
+    func importRejectsBadHash() throws {
+        let source = try makeTemporaryDirectory()
+        let destination = try makeTemporaryDirectory()
+        defer {
+            try? FileManager.default.removeItem(at: source.url)
+            try? FileManager.default.removeItem(at: destination.url)
+        }
+        try source.installBundledPlugins(from: PluginEngineResources.bundle)
+        let staged = try #require(source.installedManifestURLs().first)
+
+        // Corrupt the manifest's hash in place.
+        let data = try Data(contentsOf: staged)
+        var json = try #require(try JSONSerialization.jsonObject(with: data) as? [String: Any])
+        json["sha256"] = String(repeating: "0", count: 64)
+        try JSONSerialization.data(withJSONObject: json).write(to: staged)
+
+        #expect(throws: (any Error).self) {
+            _ = try destination.importPlugin(manifestURL: staged)
+        }
+        // Validation happens before anything is written, so the store stays empty.
+        #expect(destination.installedManifestURLs().isEmpty)
+    }
+
+    @Test("Identifiers map to filesystem-safe folder names")
+    func folderNames() {
+        #expect(PluginDirectory.folderName(for: "org.pureswift.plugin.gatt-time") == "org.pureswift.plugin.gatt-time")
+        #expect(PluginDirectory.folderName(for: "a/b:c") == "a_b_c")
+        #expect(PluginDirectory.folderName(for: "").isEmpty == false)
+    }
+}


### PR DESCRIPTION
Makes plugins a first-class, user-manageable part of the app: a top-level tab, import from a file,
and on-disk storage in Documents that bundled plugins are installed into on first launch.

Follows #20, which added the GATT characteristic plugins this manages.

## Storage

Every plugin — bundled or imported — now lives at `Documents/Plugins/<plugin-id>/`, holding its
manifest and module. One location means one load path and one place a user can actually look.

- **First launch** copies the bundled plugins in. A new app build shipping a changed module hash
  refreshes them.
- **A bundled plugin you delete stays deleted.** The install record remembers it was already
  handled, so it is not resurrected on the next launch.
- **Import validates before it writes.** The module is parsed and its ABI marker, capability exports
  and `sha256` are all checked *before* anything lands on disk, so a bad import cannot leave a
  broken plugin behind.
- **Enable/disable now persists** across launches.

If Documents is unavailable the manager falls back to loading read-only from the app bundle, so
parsing keeps working even when management does not.

## UI

Plugins is now a top-level tab rather than a row buried in Settings (the now-redundant Settings link
is removed). The screen gains an Import button, swipe-to-delete, and inline reporting of import and
load errors.

## Tests

44 pass, up from 37. The seven new ones cover the storage logic directly: first-launch install,
that installed plugins load and verify against their own hashes, idempotence on a second launch,
that a deleted bundled plugin is not resurrected, that a valid import copies and loads, that an
import with a tampered hash fails *and writes nothing*, and identifier-to-folder-name sanitising.

They run against temporary directories, never the real Documents folder — worth noting because
`PluginDirectory.default()` resolves to `~/Documents` on a macOS test host, so a careless test here
would write plugins into the developer's own home directory.

## Reviewer notes

- **iOS-focused, as requested.** `.fileImporter` and security-scoped resource access are gated
  behind `#if !os(Android)` / `#if canImport(Darwin)`. Android compiles but has no import button
  yet; the storage layer itself is portable.
- Skip's bridging plugin rejects `private @State`, so `PluginsView`'s state properties are internal
  with a comment saying why — otherwise the build fails with "cannot be bridged to Android".
- Built and tested against a machine-local reconstruction of the dependency graph; a clean checkout
  still cannot resolve. Pre-existing and unrelated — see `Documentation/DependencyState.md` on
  `feature/skip-dependency-updates`.
